### PR TITLE
Codelistoptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ todo.txt
 __pycache__/
 venv/
 .venv/
+.codegpt

--- a/bindings/python/src/codelists/codelist.rs
+++ b/bindings/python/src/codelists/codelist.rs
@@ -7,7 +7,8 @@ use pyo3::{PyResult, PyErr};
 use pyo3::types::PyDict;
 
 // Internal imports
-use codelist_rs::codelist::{CodeList, CodeListOptions};
+use codelist_rs::codelist::CodeList;
+use codelist_rs::codelist_options::CodeListOptions;
 use codelist_rs::types::CodeListType;
 use codelist_rs::metadata::{Metadata, MetadataSource};
 

--- a/rust/codelist-rs/.gitignore
+++ b/rust/codelist-rs/.gitignore
@@ -1,0 +1,2 @@
+
+.codegpt

--- a/rust/codelist-rs/.gitignore
+++ b/rust/codelist-rs/.gitignore
@@ -1,2 +1,0 @@
-
-.codegpt

--- a/rust/codelist-rs/src/codelist.rs
+++ b/rust/codelist-rs/src/codelist.rs
@@ -11,44 +11,7 @@ use crate::types::CodeListType;
 use crate::code_entry::CodeEntry;
 use crate::metadata::Metadata;
 use crate::errors::CodeListError;
-
-/// Struct to represent a codelist options
-///
-/// # Fields
-/// * `allow_duplicates` - Whether to allow duplicates in the codelist
-/// * `truncate_to_3_digits` - Whether to truncate the code to 3 digits
-/// * `add_x_codes` - Whether to add x codes to the codelist
-/// * `code_column_name` - The name of the code column
-/// * `term_column_name` - The name of the term column
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
-pub struct CodeListOptions {
-    pub allow_duplicates: bool,
-    pub truncate_to_3_digits: bool,  // ICD10 specific only
-    pub add_x_codes: bool,
-    pub code_column_name: String, // for csv files
-    pub term_column_name: String, // for csv files          
-    pub code_field_name: String, // for json files
-    pub term_field_name: String, // for json files
-
-}
-
-impl Default for CodeListOptions {
-    /// Default implementation for CodeListOptions
-    ///
-    /// # Returns
-    /// * `CodeListOptions` - The default CodeListOptions
-    fn default() -> Self {
-        Self {
-            allow_duplicates: false,
-            truncate_to_3_digits: false,
-            add_x_codes: false,
-            code_column_name: "code".to_string(),
-            term_column_name: "term".to_string(),
-            code_field_name: "code".to_string(),
-            term_field_name: "term".to_string(),
-        }
-    }
-}
+use crate::codelist_options::CodeListOptions;
 
 /// Struct to represent a codelist
 ///

--- a/rust/codelist-rs/src/codelist_factory.rs
+++ b/rust/codelist-rs/src/codelist_factory.rs
@@ -1,6 +1,6 @@
-use crate::errors::CodeListError;
+
 use crate::codelist::CodeList;
-use crate::codelist::CodeListOptions;
+use crate::codelist_options::CodeListOptions;
 use crate::metadata::{Metadata, MetadataSource};
 use crate::types::CodeListType;
 

--- a/rust/codelist-rs/src/codelist_factory.rs
+++ b/rust/codelist-rs/src/codelist_factory.rs
@@ -1,5 +1,6 @@
 
 use crate::codelist::CodeList;
+use crate::errors::CodeListError;
 use crate::codelist_options::CodeListOptions;
 use crate::metadata::{Metadata, MetadataSource};
 use crate::types::CodeListType;

--- a/rust/codelist-rs/src/codelist_options.rs
+++ b/rust/codelist-rs/src/codelist_options.rs
@@ -1,0 +1,39 @@
+use serde::{Serialize, Deserialize};
+
+/// Struct to represent a codelist options
+///
+/// # Fields
+/// * `allow_duplicates` - Whether to allow duplicates in the codelist
+/// * `truncate_to_3_digits` - Whether to truncate the code to 3 digits
+/// * `add_x_codes` - Whether to add x codes to the codelist
+/// * `code_column_name` - The name of the code column
+/// * `term_column_name` - The name of the term column
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct CodeListOptions {
+    pub allow_duplicates: bool,
+    pub truncate_to_3_digits: bool,  // ICD10 specific only
+    pub add_x_codes: bool,
+    pub code_column_name: String, // for csv files
+    pub term_column_name: String, // for csv files          
+    pub code_field_name: String, // for json files
+    pub term_field_name: String, // for json files
+
+}
+
+impl Default for CodeListOptions {
+    /// Default implementation for CodeListOptions
+    ///
+    /// # Returns
+    /// * `CodeListOptions` - The default CodeListOptions
+    fn default() -> Self {
+        Self {
+            allow_duplicates: false,
+            truncate_to_3_digits: false,
+            add_x_codes: false,
+            code_column_name: "code".to_string(),
+            term_column_name: "term".to_string(),
+            code_field_name: "code".to_string(),
+            term_field_name: "term".to_string(),
+        }
+    }
+}

--- a/rust/codelist-rs/src/codelist_options.rs
+++ b/rust/codelist-rs/src/codelist_options.rs
@@ -1,3 +1,5 @@
+//! This file contains the codelist options for the codelist
+
 use serde::{Serialize, Deserialize};
 
 /// Struct to represent a codelist options

--- a/rust/codelist-rs/src/codelist_options.rs
+++ b/rust/codelist-rs/src/codelist_options.rs
@@ -37,3 +37,20 @@ impl Default for CodeListOptions {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default() {
+        let options = CodeListOptions::default();
+        assert_eq!(options.allow_duplicates, false);
+        assert_eq!(options.truncate_to_3_digits, false);
+        assert_eq!(options.add_x_codes, false);
+        assert_eq!(options.code_column_name, "code");
+        assert_eq!(options.term_column_name, "term");
+        assert_eq!(options.code_field_name, "code");
+        assert_eq!(options.term_field_name, "term");
+    }
+}

--- a/rust/codelist-rs/src/errors.rs
+++ b/rust/codelist-rs/src/errors.rs
@@ -1,3 +1,5 @@
+//! This file contains custom errors for the codelist library
+
 use std::io;
 use serde_json;
 use csv;

--- a/rust/codelist-rs/src/lib.rs
+++ b/rust/codelist-rs/src/lib.rs
@@ -5,3 +5,4 @@ pub mod types;
 pub mod code_entry;
 pub mod metadata;
 pub mod codelist_factory;
+pub mod codelist_options;

--- a/rust/codelist-rs/src/types.rs
+++ b/rust/codelist-rs/src/types.rs
@@ -51,9 +51,9 @@ impl ToString for CodeListType {
     /// * `String` - The string representation of the CodeListType
     fn to_string(&self) -> String {
         match self {
-            CodeListType::ICD10 => "icd10".to_string(),
-            CodeListType::SNOMED => "snomed".to_string(),
-            CodeListType::OPCS => "opcs".to_string(),
+            CodeListType::ICD10 => "ICD10".to_string(),
+            CodeListType::SNOMED => "SNOMED".to_string(),
+            CodeListType::OPCS => "OPCS".to_string(),
         }
     }
 }

--- a/rust/codelist-rs/src/types.rs
+++ b/rust/codelist-rs/src/types.rs
@@ -1,4 +1,4 @@
-/// This module defines the different types of codelists that can be used
+//! This file defines the different types of codelists that can be used
 
 /// External imports
 use std::str::FromStr;

--- a/rust/codelist-rs/src/types.rs
+++ b/rust/codelist-rs/src/types.rs
@@ -80,9 +80,9 @@ mod tests {
 
     #[test]
     fn test_to_string() {
-        assert_eq!(CodeListType::ICD10.to_string(), "icd10");
-        assert_eq!(CodeListType::SNOMED.to_string(), "snomed");
-        assert_eq!(CodeListType::OPCS.to_string(), "opcs");
+        assert_eq!(CodeListType::ICD10.to_string(), "ICD10");
+        assert_eq!(CodeListType::SNOMED.to_string(), "SNOMED");
+        assert_eq!(CodeListType::OPCS.to_string(), "OPCS");
     }
 }
 


### PR DESCRIPTION
Pulled out CodelistOptions into its own file within codelist-rs and added unit tests. Also edited docs and edited codelist/code entry unit tests to make them more explicit.
Closes #25 